### PR TITLE
Update mobilus-client to fix exception error

### DIFF
--- a/custom_components/mobilus/manifest.json
+++ b/custom_components/mobilus/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/zpieslak/mobilus-client-home-assistant/issues",
   "requirements": [
-    "mobilus-client>=0.1.5"
+    "mobilus-client>=0.1.7"
   ],
   "version": "0.1.0"
 }


### PR DESCRIPTION
Fixes Caught exception in on_message: 'public_key'

#19 