### PR TITLE
Udpate mobilus-client and minimum HA version to 2025.03.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.13
       - name: Install dependencies
         run: pip install -e ".[test]"
       - name: Lint with ruff

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This integration allows you to control Mobilus Cosmo GTW devices from Home Assis
 
 ## Prerequisites
 
-- Home Assistant installation version `2024.4.0` or later (earlier versions are available in older releases - see `hacs.json` for details).
+- Home Assistant installation version `2025.3.0` or later (earlier versions are available in older releases - see `hacs.json` for details).
 - Local access to the Mobilus Cosmo GTW IP address and valid login credentials. Internet access is not required and can be disabled on the Mobilus Cosmo GTW device.
 
 ## Installation

--- a/custom_components/mobilus/manifest.json
+++ b/custom_components/mobilus/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/zpieslak/mobilus-client-home-assistant/issues",
   "requirements": [
-    "mobilus-client>=0.1.7"
+    "mobilus-client>=0.2.0"
   ],
-  "version": "0.2.3"
+  "version": "0.3.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
   "name": "Mobilus Cosmo GTW",
-  "homeassistant": "2024.4.0"
+  "homeassistant": "2025.3.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 name = "mobilus-client-home-assistant"
 dynamic = ["version"]
 dependencies = [
-  "homeassistant>=2024.4.0",
-  "mobilus-client==0.1.5",
+  "homeassistant>=2025.3.0",
+  "mobilus-client==0.2.0",
 ]
 
 [project.optional-dependencies]
@@ -13,7 +13,7 @@ test = [
   "pytest>=8.0",
   "pytest-asyncio>=0.20.0",
   "pytest-homeassistant-custom-component>=0.8",
-  "ruff>=0.6.0",
+  "ruff>=0.9.0",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
As of the upgrade of paho-mqtt client to 2.1 on HA side ([Reference](https://www.home-assistant.io/changelogs/core-2025.3/)):
- Update component to use mobilus-client version 0.2.0
- Update minimum required home assistant version to 2025.3.0

#27 