### PR TITLE
Allow state refresh interval to be configured in UI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Test
         run: coverage run -m pytest -v
       - name: Verify coverage
-        run: coverage report --fail-under=95
+        run: coverage report --fail-under=100

--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ cp -r custom_components/mobilus /var/lib/home_assistant/custom_components/
 
 Once installed, add the integration to your Home Assistant instance through UI (Settings -> Devices & Services -> Add Integration -> Mobilus COSMO GTW) and follow the UI configure setup.
 
-If needed the setup can be reconfigured through "Reconfigure" in the integration settings.
+If needed the setup can be reconfigured through "Reconfigure" in the integration settings. Possible values are the IP address, username, password, and refresh interval.
 
 Example configuration:
 
     host: 192.168.2.1
     username: admin
     password: mypassword
+    refresh_interval: 600
 
 
 ## Caveats
@@ -48,7 +49,7 @@ Currently, the integration supports Mobilus COSMO 2WAY shutters (CMR, COSMO, COS
 
 The Mobilus COSMO 2WAY shutters state is updated every 10 minutes or on each action (open, close, stop).
 
-If state updates are not working, please restart COSMO GTW device, it looks like it forcefully refreshes the state on each boot.
+If state updates are not working, please restart COSMO GTW device, it looks like it forcefully refreshes the state on each boot. For a more automated solution, you can use a smart plug that simply powers the device on and off periodically (i.e. every 24 hours).
 
 ## Usage
 

--- a/custom_components/mobilus/__init__.py
+++ b/custom_components/mobilus/__init__.py
@@ -51,7 +51,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.warning("No supported devices found in the devices list.")
         return False
 
-    coordinator = MobilusCoordinator(hass, client)
+    coordinator = MobilusCoordinator(hass, client, entry.data["refresh_interval"])
 
     hass.data[DOMAIN][entry.entry_id] = {
         "client": client,
@@ -71,3 +71,14 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    if config_entry.version == 1:
+        data = dict(config_entry.data)
+
+        if "refresh_interval" not in data:
+            data["refresh_interval"] = 600
+
+    hass.config_entries.async_update_entry(config_entry, data=data)
+
+    return True

--- a/custom_components/mobilus/config_flow.py
+++ b/custom_components/mobilus/config_flow.py
@@ -9,7 +9,7 @@ from .const import DOMAIN
 
 
 class MobilusConfigFlow(ConfigFlow, domain=DOMAIN):
-    VERSION = 1
+    VERSION = 2
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         if user_input is not None:
@@ -50,4 +50,5 @@ class MobilusConfigFlow(ConfigFlow, domain=DOMAIN):
             vol.Required("host", default=defaults.get("host", None)): str,
             vol.Required("username", default=defaults.get("username", None)): str,
             vol.Required("password", default=defaults.get("password", None)): str,
+            vol.Required("refresh_interval", default=defaults.get("refresh_interval", 600)): int,
         })

--- a/custom_components/mobilus/coordinator.py
+++ b/custom_components/mobilus/coordinator.py
@@ -21,14 +21,16 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class MobilusCoordinator(DataUpdateCoordinator[MobilusDeviceStateList]):
-    def __init__(self, hass: HomeAssistant, client: MobilusClientApp) -> None:
+    def __init__(self, hass: HomeAssistant, client: MobilusClientApp, refresh_interval: int) -> None:
         self.client = client
+
+        _LOGGER.info("Coordinator initialized with refresh interval %s", refresh_interval)
 
         super().__init__(
             hass,
             _LOGGER,
             name=f"{DOMAIN}_coordinator",
-            update_interval=timedelta(seconds=600),
+            update_interval=timedelta(seconds=refresh_interval),
         )
 
     async def _async_update_data(self) -> MobilusDeviceStateList:

--- a/custom_components/mobilus/manifest.json
+++ b/custom_components/mobilus/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/zpieslak/mobilus-client-home-assistant/issues",
   "requirements": [
-    "mobilus-client>=0.2.0"
+    "mobilus-client==0.2.0"
   ],
-  "version": "0.3.0"
+  "version": "0.3.1"
 }

--- a/custom_components/mobilus/translations/en.json
+++ b/custom_components/mobilus/translations/en.json
@@ -7,7 +7,8 @@
         "data": {
           "host": "IP Address / Host",
           "username": "Username",
-          "password": "Password"
+          "password": "Password",
+          "refresh_interval": "State refresh interval (in seconds)"
         }
       },
       "reconfigure": {
@@ -16,7 +17,8 @@
         "data": {
           "host": "IP Address / Host",
           "username": "Username",
-          "password": "Password"
+          "password": "Password",
+          "refresh_interval": "State refresh interval (in seconds)"
         }
       }
     },

--- a/custom_components/mobilus/translations/pl.json
+++ b/custom_components/mobilus/translations/pl.json
@@ -7,7 +7,8 @@
         "data": {
           "host": "Adres IP / Host",
           "username": "Nazwa użytkownika",
-          "password": "Hasło"
+          "password": "Hasło",
+          "refresh_interval": "Interwał odświeżania stanu (w sekundach)"
         }
       },
       "reconfigure": {
@@ -16,7 +17,8 @@
         "data": {
           "host": "Adres IP / Host",
           "username": "Nazwa użytkownika",
-          "password": "Hasło"
+          "password": "Hasło",
+          "refresh_interval": "Interwał odświeżania stanu (w sekundach)"
         }
       }
     },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,5 +30,6 @@ def mock_config_entry() -> MockConfigEntry:
             "host": "test_host",
             "username": "test_user",
             "password": "test_pass",
+            "refresh_interval": 600,
         },
     )


### PR DESCRIPTION
Add new configurable option `refresh_interval` that is used as current hard-coded value in Coordinator.

![screenshot_20250323T070415Z](https://github.com/user-attachments/assets/0aec09b6-6f85-4689-aa43-f5ef100627b4)

Reference #24 

Closes #29 