### PR TITLE
feat: add switch platform support for mobilus devices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Test
+name: CI
 
 on:
   push:
@@ -8,7 +8,8 @@ on:
     branches:
       - main
 jobs:
-  build:
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -16,13 +17,25 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.13
+          python-version: "3.13"
       - name: Install dependencies
         run: pip install -e ".[test]"
       - name: Lint with ruff
         run: ruff check --output-format=github .
       - name: Lint with mypy
         run: mypy .
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        run: pip install -e ".[test]"
       - name: Test
         run: coverage run -m pytest -v
       - name: Verify coverage

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Example configuration:
 
 ## Caveats
 
-Currently, the integration supports Mobilus COSMO 2WAY shutters (CMR, COSMO, COSMO_CZR, COSMO_MZR, SENSO, and SENSO_Z). Other devices compatible with the Mobilus Cosmo GTW (CGR, SWITCH, SWITCH_NP) are not supported by this plugin at this time, as they do not provide the Mobilus shutter API and I am unable to test them.
+Currently, the integration supports Mobilus COSMO 2WAY shutters (CMR, COSMO, COSMO_CZR, COSMO_MZR, SENSO, and SENSO_Z) and switches (SWITCH, SWITCH_NP). Other devices compatible with the Mobilus Cosmo GTW (CGR) are not supported by this plugin at this time, as I do not have access to these devices for testing. Contributions are welcome!
 
-The Mobilus COSMO 2WAY shutters state is updated every 10 minutes or on each action (open, close, stop).
+The Mobilus COSMO 2WAY devices state is updated every 10 minutes or on each action (open, close, stop, turn on, turn off).
 
 If state updates are not working, please restart COSMO GTW device, it looks like it forcefully refreshes the state on each boot. For a more automated solution, you can use a smart plug that simply powers the device on and off periodically (i.e. every 24 hours).
 

--- a/custom_components/mobilus/__init__.py
+++ b/custom_components/mobilus/__init__.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 from mobilus_client.app import App as MobilusClientApp
 from mobilus_client.config import Config as MobilusClientConfig
 
-from .const import DOMAIN, PLATFORMS, SUPPORTED_DEVICES
+from .const import DOMAIN, NOT_SUPPORTED_DEVICES, PLATFORMS
 from .coordinator import MobilusCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,10 +41,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.warning("No devices found in the devices list.")
         return False
 
-    # Currently non cover devices are not supported
+    # Remove not supported devices
     supported_devices = [
         device for device in devices
-        if device["type"] in SUPPORTED_DEVICES
+        if device["type"] not in NOT_SUPPORTED_DEVICES
     ]
 
     if not supported_devices:

--- a/custom_components/mobilus/const.py
+++ b/custom_components/mobilus/const.py
@@ -4,28 +4,31 @@ from .device import MobilusDevice
 
 DOMAIN = "mobilus"
 
-PLATFORMS = [Platform.COVER]
+PLATFORMS = [Platform.COVER, Platform.SWITCH]
 
 NOT_SUPPORTED_DEVICES = (
     MobilusDevice.CGR,
-    MobilusDevice.SWITCH,
-    MobilusDevice.SWITCH_NP,
 )
 
-POSITION_SUPPORTED_DEVICES = (
-    MobilusDevice.SENSO,
-    MobilusDevice.SENSO_Z,
-)
-
-TILT_SUPPORTED_DEVICES = (
-    MobilusDevice.COSMO_CZR,
-)
-
-SUPPORTED_DEVICES = (
+COVER_DEVICES = (
     MobilusDevice.CMR,
     MobilusDevice.COSMO,
     MobilusDevice.COSMO_CZR,
     MobilusDevice.COSMO_MZR,
     MobilusDevice.SENSO,
     MobilusDevice.SENSO_Z,
+)
+
+COVER_POSITION_DEVICES = (
+    MobilusDevice.SENSO,
+    MobilusDevice.SENSO_Z,
+)
+
+COVER_TILT_DEVICES = (
+    MobilusDevice.COSMO_CZR,
+)
+
+SWITCH_DEVICES = (
+    MobilusDevice.SWITCH,
+    MobilusDevice.SWITCH_NP,
 )

--- a/custom_components/mobilus/cover.py
+++ b/custom_components/mobilus/cover.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.components.cover import CoverDeviceClass, CoverEntity, CoverEntityFeature
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, POSITION_SUPPORTED_DEVICES, TILT_SUPPORTED_DEVICES
+from .const import COVER_DEVICES, COVER_POSITION_DEVICES, COVER_TILT_DEVICES, DOMAIN
 from .coordinator import MobilusCoordinator
 
 if TYPE_CHECKING:
@@ -27,9 +27,10 @@ async def async_setup_entry(
     devices = hass.data[DOMAIN][entry.entry_id]["devices"]
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
-    async_add_entities(
-      [MobilusCover(device, client, coordinator) for device in devices],
-    )
+    async_add_entities([
+        MobilusCover(device, client, coordinator)
+        for device in devices if device["type"] in COVER_DEVICES
+    ])
 
 class MobilusCover(CoordinatorEntity[MobilusCoordinator], CoverEntity):
     def __init__(self, device: dict[str, Any], client: MobilusClientApp, coordinator: MobilusCoordinator) -> None:
@@ -57,10 +58,10 @@ class MobilusCover(CoordinatorEntity[MobilusCoordinator], CoverEntity):
             | CoverEntityFeature.STOP
         )
 
-        if self.device["type"] in POSITION_SUPPORTED_DEVICES:
+        if self.device["type"] in COVER_POSITION_DEVICES:
             supported_features |= CoverEntityFeature.SET_POSITION
 
-        if self.device["type"] in TILT_SUPPORTED_DEVICES:
+        if self.device["type"] in COVER_TILT_DEVICES:
             supported_features |= (
                 CoverEntityFeature.OPEN_TILT
                 | CoverEntityFeature.CLOSE_TILT

--- a/custom_components/mobilus/device_state.py
+++ b/custom_components/mobilus/device_state.py
@@ -13,6 +13,9 @@ class MobilusDeviceStateList:
 @dataclass
 class MobilusDeviceState:
     EVENT_NUMBER_MOVING = 7
+    STATE_DOWN = "DOWN"
+    STATE_ON = "ON"
+    STATE_UP = "UP"
 
     device_id: str
     event_number: int
@@ -20,10 +23,10 @@ class MobilusDeviceState:
 
     @cached_property
     def cover_position(self) -> int | None:
-        if self._main_position == "UP":
+        if self._main_position == self.STATE_UP:
             return 100
 
-        if self._main_position == "DOWN":
+        if self._main_position == self.STATE_DOWN:
             return 0
 
         # Reject STOP or other non-numeric position for cover
@@ -46,6 +49,10 @@ class MobilusDeviceState:
             return self._main_position
 
         return self._additional_position
+
+    @cached_property
+    def is_on(self) -> bool:
+        return self._main_position == self.STATE_ON
 
     @cached_property
     def _is_moving(self) -> bool:

--- a/custom_components/mobilus/manifest.json
+++ b/custom_components/mobilus/manifest.json
@@ -13,5 +13,5 @@
   "requirements": [
     "mobilus-client==0.2.0"
   ],
-  "version": "0.3.1"
+  "version": "0.4.0"
 }

--- a/custom_components/mobilus/switch.py
+++ b/custom_components/mobilus/switch.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, SWITCH_DEVICES
+from .coordinator import MobilusCoordinator
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+    from mobilus_client.app import App as MobilusClientApp
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    client = hass.data[DOMAIN][entry.entry_id]["client"]
+    devices = hass.data[DOMAIN][entry.entry_id]["devices"]
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+
+    async_add_entities([
+        MobilusSwitch(device, client, coordinator)
+        for device in devices if device["type"] in SWITCH_DEVICES
+    ])
+
+class MobilusSwitch(CoordinatorEntity[MobilusCoordinator], SwitchEntity):
+    def __init__(self, device: dict[str, Any], client: MobilusClientApp, coordinator: MobilusCoordinator) -> None:
+        self.client = client
+        self.coordinator = coordinator
+        self.device = device
+
+    @property
+    def unique_id(self) -> str:
+        return f"{DOMAIN}_{self.device['id']}"
+
+    @property
+    def name(self) -> str:
+        return str(self.device["name"])
+
+    @property
+    def is_on(self) -> bool:
+        device_status = self.coordinator.data.devices.get(self.device["id"])
+
+        if not device_status:
+            return False
+
+        return device_status.is_on
+
+    async def async_turn_on(self, **_kwargs: Any) -> None: # noqa: ANN401
+        _LOGGER.info("Turning ON switch %s", self.device["name"])
+
+        await self.hass.async_add_executor_job(
+            self.client.call,
+            [("call_events", {"device_id": self.device["id"], "value": "ON"})],
+        )
+
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **_kwargs: Any) -> None: # noqa: ANN401
+        _LOGGER.info("Turning OFF switch %s", self.device["name"])
+
+        await self.hass.async_add_executor_job(
+            self.client.call,
+            [("call_events", {"device_id": self.device["id"], "value": "OFF"})],
+        )
+
+        await self.coordinator.async_request_refresh()
+
+    async def async_added_to_hass(self) -> None:
+        # Add a listener to the coordinator to update the entity's state on data changes
+        coordinator_listener = self.coordinator.async_add_listener(self.async_write_ha_state)
+
+        # Register the listener for cleanup when the entity is removed from Home Assistant
+        self.async_on_remove(coordinator_listener)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -55,6 +55,7 @@ async def test_coordinator_async_update_data_success(
                     {"deviceId": "device08", "value": "DOWN:32$", "eventNumber": 8},
                     {"deviceId": "device09", "value": "56%:$", "eventNumber": 8},
                     {"deviceId": "device10", "value": "UNKNOWN", "eventNumber": 8},
+                    {"deviceId": "device11", "value": "ON", "eventNumber": 8},
                 ],
             },
         ],
@@ -64,7 +65,7 @@ async def test_coordinator_async_update_data_success(
     data = await coordinator._async_update_data() # noqa: SLF001
 
     assert isinstance(data, MobilusDeviceStateList)
-    assert len(data.devices) == 11
+    assert len(data.devices) == 12
     assert data.devices["device00"].cover_position == 45
     assert data.devices["device01"].cover_position == 12
     assert data.devices["device02"].cover_position == 50
@@ -88,3 +89,5 @@ async def test_coordinator_async_update_data_success(
     assert data.devices["device08"].tilt_position == 32
     assert data.devices["device09"].tilt_position is None
     assert data.devices["device10"].tilt_position is None
+
+    assert data.devices["device11"].is_on is True

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -28,15 +28,20 @@ async def test_async_setup_entry(
         hass: HomeAssistant, mock_client: Mock, mock_coordinator: Mock,
         mock_config_entry: MockConfigEntry, mock_async_add_entities: Mock) -> None:
 
+    device_cosmo = {
+        "id": "1",
+        "name": "Device COSMO",
+        "type": 2,
+    }
     device_senso = {
         "id": "0",
         "name": "Device SENSO",
         "type": 1,
     }
-    device_cosmo = {
-        "id": "1",
-        "name": "Device COSMO",
-        "type": 2,
+    device_switch = {
+        "id": "0",
+        "name": "Device SWITCH",
+        "type": 5,
     }
 
     hass.data[DOMAIN] = {}
@@ -44,8 +49,9 @@ async def test_async_setup_entry(
         "client": mock_client,
         "coordinator": mock_coordinator,
         "devices": [
-            device_senso,
             device_cosmo,
+            device_senso,
+            device_switch,
         ],
     }
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -123,6 +123,16 @@ async def test_async_setup_entry(
                 "type": 3,
             },
             {
+              "id": "4",
+              "name": "Device SWITCH",
+              "type": 5,
+            },
+            {
+              "id": "5",
+              "name": "Device SWITCH_NP",
+              "type": 6,
+            },
+            {
                 "id": "6",
                 "name": "Device COSMO_CZR",
                 "type": 7,
@@ -183,8 +193,8 @@ async def test_async_setup_entry_no_supported_devices(
             "devices": [
               {
                 "id": "0",
-                "name": "Device SWITCH",
-                "type": 5,
+                "name": "Device CGR",
+                "type": 4,
               },
           ]},
         ],

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import Mock, patch
+
+import pytest
+
+from custom_components.mobilus.const import DOMAIN
+from custom_components.mobilus.switch import MobilusSwitch, async_setup_entry
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+@pytest.fixture
+def mock_async_add_entities() -> Mock:
+    return Mock()
+
+async def test_async_setup_entry(
+    hass: HomeAssistant,
+    mock_client: Mock,
+    mock_coordinator: Mock,
+    mock_config_entry: MockConfigEntry,
+    mock_async_add_entities: Mock,
+) -> None:
+    device_cosmo = {
+        "id": "1",
+        "name": "Device COSMO",
+        "type": 2,
+    }
+    device_switch = {
+        "id": "0",
+        "name": "Device SWITCH",
+        "type": 5,
+    }
+    device_switch_np = {
+        "id": "1",
+        "name": "Device SWITCH_NP",
+        "type": 6,
+    }
+
+    hass.data[DOMAIN] = {}
+    hass.data[DOMAIN][mock_config_entry.entry_id] = {
+        "client": mock_client,
+        "coordinator": mock_coordinator,
+        "devices": [
+            device_cosmo,
+            device_switch,
+            device_switch_np,
+        ],
+    }
+
+    await async_setup_entry(hass, mock_config_entry, mock_async_add_entities)
+
+    assert mock_async_add_entities.call_with(
+        [
+            MobilusSwitch(device_switch, mock_client, mock_coordinator),
+            MobilusSwitch(device_switch_np, mock_client, mock_coordinator),
+        ],
+    )
+
+
+def test_switch_init(mock_client: Mock, mock_coordinator: Mock) -> None:
+    device = {
+        "id": "3",
+        "name": "Test Switch",
+        "type": 5,
+    }
+    switch = MobilusSwitch(device, mock_client, mock_coordinator)
+
+    assert switch.coordinator == mock_coordinator
+    assert switch.device == device
+    assert switch.client == mock_client
+
+
+def test_switch_unique_id(mock_client: Mock, mock_coordinator: Mock) -> None:
+    device = {
+        "id": "3",
+        "name": "Test Switch",
+        "type": 5,
+    }
+    switch = MobilusSwitch(device, mock_client, mock_coordinator)
+
+    assert switch.unique_id == "mobilus_3"
+
+
+def test_switch_name(mock_client: Mock, mock_coordinator: Mock) -> None:
+    device = {
+        "id": "3",
+        "name": "Test Switch",
+        "type": 5,
+    }
+    switch = MobilusSwitch(device, mock_client, mock_coordinator)
+
+    assert switch.name == "Test Switch"
+
+
+def test_switch_is_on_true(mock_client: Mock, mock_coordinator: Mock) -> None:
+    device_status = Mock()
+    device_status.is_on = True
+    mock_coordinator.data.devices = {
+        "3": device_status,
+    }
+
+    device = {
+        "id": "3",
+        "name": "Test Switch",
+        "type": 5,
+    }
+    switch = MobilusSwitch(device, mock_client, mock_coordinator)
+
+    assert switch.is_on
+
+
+def test_switch_is_on_false(mock_client: Mock, mock_coordinator: Mock) -> None:
+    device_status = Mock()
+    device_status.is_on = False
+    mock_coordinator.data.devices = {
+        "3": device_status,
+    }
+
+    device = {
+        "id": "3",
+        "name": "Test Switch",
+        "type": 5,
+    }
+    switch = MobilusSwitch(device, mock_client, mock_coordinator)
+
+    assert not switch.is_on
+
+
+def test_switch_is_on_no_device_status(mock_client: Mock, mock_coordinator: Mock) -> None:
+    mock_coordinator.data.devices = {}
+
+    device = {
+        "id": "3",
+        "name": "Test Switch",
+        "type": 5,
+    }
+    switch = MobilusSwitch(device, mock_client, mock_coordinator)
+
+    assert not switch.is_on
+
+
+def test_switch_is_on_none_device_status(mock_client: Mock, mock_coordinator: Mock) -> None:
+    mock_coordinator.data.devices = {
+        "3": None,
+    }
+
+    device = {
+        "id": "3",
+        "name": "Test Switch",
+        "type": 5,
+    }
+    switch = MobilusSwitch(device, mock_client, mock_coordinator)
+
+    assert not switch.is_on
+
+
+async def test_switch_async_turn_on(
+    hass: HomeAssistant, mock_client: Mock, mock_coordinator: Mock,
+) -> None:
+    device = {
+        "id": "3",
+        "name": "Test Switch",
+        "type": 5,
+    }
+    switch = MobilusSwitch(device, mock_client, mock_coordinator)
+    switch.hass = hass
+
+    await switch.async_turn_on()
+
+    mock_client.call.assert_called_once_with(
+        [("call_events", {"device_id": "3", "value": "ON"})],
+    )
+    mock_coordinator.async_request_refresh.assert_called_once()
+
+
+async def test_switch_async_turn_off(
+    hass: HomeAssistant, mock_client: Mock, mock_coordinator: Mock,
+) -> None:
+    device = {
+        "id": "3",
+        "name": "Test Switch",
+        "type": 5,
+    }
+    switch = MobilusSwitch(device, mock_client, mock_coordinator)
+    switch.hass = hass
+
+    await switch.async_turn_off()
+
+    mock_client.call.assert_called_once_with(
+        [("call_events", {"device_id": "3", "value": "OFF"})],
+    )
+    mock_coordinator.async_request_refresh.assert_called_once()
+
+
+async def test_switch_async_added_to_hass(
+    hass: HomeAssistant, mock_client: Mock, mock_coordinator: Mock,
+) -> None:
+    device = {
+        "id": "3",
+        "name": "Test Switch",
+        "type": 5,
+    }
+    switch = MobilusSwitch(device, mock_client, mock_coordinator)
+    switch.hass = hass
+
+    with patch.object(switch, "async_on_remove", new=Mock()) as mock_async_on_remove:
+        await switch.async_added_to_hass()
+
+        mock_coordinator.async_add_listener.assert_called_once_with(
+            switch.async_write_ha_state,
+        )
+        mock_async_on_remove.assert_called_once_with(
+            mock_coordinator.async_add_listener.return_value,
+        )
+


### PR DESCRIPTION
- Add switch platform to support C-SWP and C-SW devices
- Refactor const.py to use device type groupings instead of exclusion
- Update cover platform to filter devices by COVER_DEVICES
- Add is_on property to MobilusDeviceState for switch states
- Rename workflow from "Test" to "CI" and split lint/test jobs
- Update version to 0.4.0 in manifest
- Add comprehensive test coverage for switch functionality

Based on the code in pull request: https://github.com/zpieslak/mobilus-client-home-assistant/pull/31