### PR TITLE
feat: add garage door support for CGR devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![test workflow](https://github.com/zpieslak/mobilus-client-home-assistant/actions/workflows/ci.yml/badge.svg)
 ![hassfest workflow](https://github.com/zpieslak/mobilus-client-home-assistant/actions/workflows/hassfest.yml/badge.svg)
 
-This integration allows you to control Mobilus Cosmo GTW devices from Home Assistant, specifically the Mobilus COSMO 2WAY shutters. Internally, it uses the [Mobilus client library](https://github.com/zpieslak/mobilus-client) to communicate with the Mobilus Cosmo GTW.
+This integration allows you to control Mobilus Cosmo GTW devices from Home Assistant, specifically the Mobilus COSMO 2WAY shutters. Internally, it uses the [Mobilus client library](https://github.com/zpieslak/mobilus-client) to communicate with the Mobilus Cosmo GTW. Communication is performed over the **local network**, so no external internet access is required.
 
 ## Prerequisites
 
@@ -45,7 +45,7 @@ Example configuration:
 
 ## Caveats
 
-The integration currently supports Mobilus COSMO 2WAY shutters (CMR, COSMO, COSMO_CZR, COSMO_MZR, SENSO, and SENSO_Z) and switches (C-SW, C-SWP). Other devices compatible with the Mobilus Cosmo GTW (CGR) aren't supported yet, as I don’t have access to them for testing - but contributions are very welcome!
+The integration currently supports Mobilus COSMO 2WAY shutters (CMR, COSMO, COSMO_CZR, COSMO_MZR, SENSO, and SENSO_Z), switches (C-SW, C-SWP) and garage doors (CGR). Contributions that improve functionality are very welcome!
 
 The Mobilus COSMO 2WAY devices state is updated every 10 minutes or on each action (open, close, stop, turn on, turn off).
 

--- a/custom_components/mobilus/__init__.py
+++ b/custom_components/mobilus/__init__.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 from mobilus_client.app import App as MobilusClientApp
 from mobilus_client.config import Config as MobilusClientConfig
 
-from .const import DOMAIN, NOT_SUPPORTED_DEVICES, PLATFORMS
+from .const import DOMAIN, PLATFORMS
 from .coordinator import MobilusCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,22 +41,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.warning("No devices found in the devices list.")
         return False
 
-    # Remove not supported devices
-    supported_devices = [
-        device for device in devices
-        if device["type"] not in NOT_SUPPORTED_DEVICES
-    ]
-
-    if not supported_devices:
-        _LOGGER.warning("No supported devices found in the devices list.")
-        return False
-
     coordinator = MobilusCoordinator(hass, client, entry.data["refresh_interval"])
 
     hass.data[DOMAIN][entry.entry_id] = {
         "client": client,
         "coordinator": coordinator,
-        "devices": supported_devices,
+        "devices": devices,
     }
 
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/mobilus/const.py
+++ b/custom_components/mobilus/const.py
@@ -6,10 +6,6 @@ DOMAIN = "mobilus"
 
 PLATFORMS = [Platform.COVER, Platform.SWITCH]
 
-NOT_SUPPORTED_DEVICES = (
-    MobilusDevice.CGR,
-)
-
 COVER_DEVICES = (
     MobilusDevice.CMR,
     MobilusDevice.COSMO,
@@ -26,6 +22,10 @@ COVER_POSITION_DEVICES = (
 
 COVER_TILT_DEVICES = (
     MobilusDevice.COSMO_CZR,
+)
+
+GARAGE_DEVICES = (
+    MobilusDevice.CGR,
 )
 
 SWITCH_DEVICES = (

--- a/custom_components/mobilus/manifest.json
+++ b/custom_components/mobilus/manifest.json
@@ -13,5 +13,5 @@
   "requirements": [
     "mobilus-client==0.2.0"
   ],
-  "version": "0.4.0"
+  "version": "0.5.0"
 }

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -38,6 +38,11 @@ async def test_async_setup_entry(
         "name": "Device SENSO",
         "type": 1,
     }
+    device_cgr = {
+        "id": "2",
+        "name": "Device CGR",
+        "type": 4,
+    }
     device_switch = {
         "id": "0",
         "name": "Device SWITCH",
@@ -52,6 +57,7 @@ async def test_async_setup_entry(
             device_cosmo,
             device_senso,
             device_switch,
+            device_cgr,
         ],
     }
 
@@ -61,6 +67,7 @@ async def test_async_setup_entry(
       [
           MobilusCover(device_senso, mock_client, mock_coordinator),
           MobilusCover(device_cosmo, mock_client, mock_coordinator),
+          MobilusCover(device_cgr, mock_client, mock_coordinator),
       ],
     )
 
@@ -105,6 +112,17 @@ def test_cover_device_class(mock_client: Mock, mock_coordinator: Mock) -> None:
     cover = MobilusCover(device, mock_client, mock_coordinator)
 
     assert cover.device_class == CoverDeviceClass.SHUTTER
+
+def test_cover_garage_device_class(mock_client: Mock, mock_coordinator: Mock) -> None:
+    device = {
+        "id": "3",
+        "name": "Device CGR",
+        "type": 4,
+    }
+    cover = MobilusCover(device, mock_client, mock_coordinator)
+
+    assert cover.device_class == CoverDeviceClass.GARAGE
+
 
 def test_cover_supported_features(mock_client: Mock, mock_coordinator: Mock) -> None:
     device = {
@@ -372,6 +390,24 @@ async def test_cover_async_stop_cover(hass: HomeAssistant, mock_client: Mock, mo
         [("call_events", {"device_id": "3", "value": "STOP"})],
     )
     mock_coordinator.async_request_refresh.assert_called_once()
+
+@pytest.mark.usefixtures("mock_asyncio_sleep")
+async def test_cover_garage_async_stop_cover(hass: HomeAssistant, mock_client: Mock, mock_coordinator: Mock) -> None:
+    device = {
+        "id": "3",
+        "name": "Device CGR",
+        "type": 4,
+    }
+    cover = MobilusCover(device, mock_client, mock_coordinator)
+    cover.hass = hass
+
+    await cover.async_stop_cover()
+
+    mock_client.call.assert_called_once_with(
+        [("call_events", {"device_id": "3", "value": "UP"})],
+    )
+    mock_coordinator.async_request_refresh.assert_called_once()
+
 
 async def test_cover_async_set_cover_position(hass: HomeAssistant, mock_client: Mock, mock_coordinator: Mock) -> None:
     device = {

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -123,6 +123,11 @@ async def test_async_setup_entry(
                 "type": 3,
             },
             {
+              "id": "3",
+              "name": "Device CGR",
+              "type": 4,
+            },
+            {
               "id": "4",
               "name": "Device SWITCH",
               "type": 5,
@@ -180,30 +185,6 @@ async def test_async_setup_entry_no_device_in_response(
 
     mock_logger.warning.assert_called_once_with("No devices found in the devices list.")
     assert(hass.data[DOMAIN]) == {}
-    assert mock_coordinator.async_config_entry_first_refresh.call_count == 0
-    assert mock_forward_entry_setups.call_count == 0
-
-async def test_async_setup_entry_no_supported_devices(
-        hass: HomeAssistant, mock_client: Mock, mock_config_entry: MockConfigEntry,
-        mock_coordinator: Mock, mock_forward_entry_setups: AsyncMock, mock_logger: Mock) -> None:
-
-    mock_client.call.return_value = json.dumps(
-        [
-          {
-            "devices": [
-              {
-                "id": "0",
-                "name": "Device CGR",
-                "type": 4,
-              },
-          ]},
-        ],
-    )
-
-    result = await async_setup_entry(hass, mock_config_entry)
-
-    assert not result
-    mock_logger.warning.assert_called_once_with("No supported devices found in the devices list.")
     assert mock_coordinator.async_config_entry_first_refresh.call_count == 0
     assert mock_forward_entry_setups.call_count == 0
 


### PR DESCRIPTION
- Remove NOT_SUPPORTED_DEVICES filtering from init
- Add GARAGE_DEVICES constant for CGR device type
- Update tests to include CGR devices and remove unsupported device test

CGR devices are now supported as garage door covers with open/close/stop
functionality.

Closes #38