### PR TITLE
fix: update compatible dependency versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install dependencies
         run: pip install -e ".[test]"
       - name: Lint with ruff
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install dependencies
         run: pip install -e ".[test]"
       - name: Test

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This integration allows you to control Mobilus Cosmo GTW devices from Home Assis
 
 ## Prerequisites
 
-- Home Assistant installation version `2025.3.0` or later (earlier versions are available in older releases - see `hacs.json` for details).
+- Home Assistant installation version `2026.5.0` or later (earlier versions are available in older releases - see `hacs.json` for details).
 - Local access to the Mobilus Cosmo GTW IP address and valid login credentials. Internet access is not required and can be disabled on the Mobilus Cosmo GTW device.
 
 ## Installation

--- a/custom_components/mobilus/manifest.json
+++ b/custom_components/mobilus/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/zpieslak/mobilus-client-home-assistant/issues",
   "requirements": [
-    "mobilus-client==0.2.0"
+    "mobilus-client==0.2.1"
   ],
-  "version": "0.5.0"
+  "version": "0.5.1"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
   "name": "Mobilus Cosmo GTW",
-  "homeassistant": "2025.3.0"
+  "homeassistant": "2026.5.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 name = "mobilus-client-home-assistant"
 dynamic = ["version"]
 dependencies = [
-  "homeassistant>=2025.3.0",
-  "mobilus-client==0.2.0",
+  "homeassistant>=2026.5.0",
+  "mobilus-client==0.2.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- update `mobilus-client` to 0.2.1 and require Home Assistant 2026.5.0
- update the HACS and README compatibility declarations
- bump the integration to 0.5.1 and run CI on Python 3.14

## Testing

- Ruff passed
- mypy passed
- test suite passed

Fixes #42